### PR TITLE
Adding canonical-path on dependecies

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Install [Node](http://nodejs.org/), if you don't have it allready. After that yo
 Dgeni and an additional module with basic plugins for Dgeni called `dgeni-packages`:
 
 ```bash
-$ npm install --save-dev dgeni dgeni-packages
+$ npm install --save-dev dgeni dgeni-packages canonical-path
 ```
 
 # How can I use Dgeni with Grunt?


### PR DESCRIPTION
I would like to give a suggestion which is to replace the first npm install to this one: 
<code>npm install --save-dev dgeni dgeni-packages canonical-path</code>

Because only seeing on the grunt-file can realize that the canonical-path module is needed.
